### PR TITLE
#2 Routing now Scrolls to top

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,11 +10,13 @@ import ReactPoject from './componets/content/reactProject'
 import ThisSiteProject from './componets/content/thisSiteProject'
 import DiscordBot from './componets/content/discordBot'
 import MobileContext from './componets/helpers/mobilehelper';
+import ScrollToTop from './componets/helpers/scrollHook'
 import { GlobalContextComponet } from './componets/helpers/globalContext';
 
 const App = () => {
   return (
     <Router>
+      <ScrollToTop>
       <MobileContext>
         <GlobalContextComponet>
         <div id='page-container'>
@@ -39,6 +41,7 @@ const App = () => {
         </div>
         </GlobalContextComponet>
       </MobileContext>
+      </ScrollToTop>
     </Router>
   )
 }

--- a/src/componets/helpers/scrollHook.tsx
+++ b/src/componets/helpers/scrollHook.tsx
@@ -1,0 +1,23 @@
+import React, { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const RouterScollHook: React.FC = (props) => {
+    const { pathname } = useLocation();
+    debugger;
+    useEffect(() => {
+        debugger;
+        window.scrollTo({
+            top: 0,
+            left: 0,
+            behavior: "smooth"
+        });
+    }, [pathname]);
+
+    return (
+        <>
+            {props.children}
+        </>
+    )
+}
+
+export default RouterScollHook


### PR DESCRIPTION
Linking within the app will cause it to scroll to the top instead of being left scrolled down to where you where on the old page.